### PR TITLE
feat: Deployment to ECR Private Repository using Github Action

### DIFF
--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -45,6 +45,6 @@ jobs:
           REPOSITORY: im-label-studio
           IMAGE_TAG: 'latest'
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          scripts/build_docker.sh
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -44,6 +44,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: im-label-studio
           IMAGE_TAG: 'latest'
-        run: scripts/build_docker.sh
-          # docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          # echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   DeployLabelStudio:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) || github.event_name == 'push'
     steps:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -44,7 +44,6 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: im-label-studio
           IMAGE_TAG: 'latest'
-        run: |
-          scripts/build_docker.sh
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"
+        run: scripts/build_docker.sh
+          # docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          # echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -25,19 +25,20 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::626309225955:role/AssumeRoleLabelStudioRepo
           role-session-name: DeployLabelStudio
           aws-region: us-east-1
-      - name: Get Caller Identity
-        run: aws sts get-caller-identity
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
           mask-password: 'true'
+
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   DeployLabelStudio:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) || github.event_name == 'push'
     steps:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -4,7 +4,7 @@ name: Deploy Label Studio
 on:
   push:
     branches:
-      - 'feature/*'
+      - 'main'
   workflow_dispatch:
     inputs:
       BuildPushImage:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -4,7 +4,7 @@ name: Deploy Label Studio
 on:
   push:
     branches:
-      - 'main'
+      - 'feature/*'
   workflow_dispatch:
     inputs:
       BuildPushImage:
@@ -43,7 +43,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: im-label-studio
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: 'latest'
         run: |
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   DeployLabelStudio:
-    runs-on: [self-hosted, macOS, Mac04Agent]
+    runs-on: [self-hosted, macOS]
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) ||
          github.event_name == 'push'
     steps:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -38,12 +38,14 @@ jobs:
           mask-password: 'true'
       - name: LS
         run: ls -la
+      - name: LS backwards
+        run: ls -la ../
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: im-label-studio
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG Dockerfile
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ${GITHUB_WORKSPACE}/Dockerfile
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   DeployLabelStudio:
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted]
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) ||
          github.event_name == 'push'
     steps:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: LS
         run: ls -la
       - name: LS backwards
-        run: ls -la ../
+        run: ls -la ../label-studio/
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -16,15 +16,17 @@ on:
 jobs:
   DeployLabelStudio:
     runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) || github.event_name == 'push'
     steps:
       - name: Configure AWS Credentials
-        id: creds
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::626309225955:role/AssumeRoleLabelStudioRepo
-          output-credentials: true
+          aws-region: us-east-1
       - name: Get Caller Identity
         run: aws sts get-caller-identity
       - name: Login to Amazon ECR

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -1,0 +1,31 @@
+name: Deploy Label Studio
+
+# Continuous LDSDK jobs on all branches but feature branches. In feature branches, they will get triggered by pull request
+on:
+  push:
+    branches:
+      - 'feature/*'
+  workflow_dispatch:
+    inputs:
+      BuildPushImage:
+        type: boolean
+        description: 'Build & Push Image to ECR'
+        required: true
+        default: "true"      
+
+jobs:
+  DeployLabelStudio:
+    runs-on: [self-hosted, macOS, Mac04Agent]
+    if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) ||
+         github.event_name == 'push'
+    steps:
+      - name: Configure AWS Credentials
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::626309225955:role/AssumeRoleLabelStudioRepo
+          output-credentials: true
+      - name: Get Caller Identity
+        run: |
+          aws sts get-caller-identity

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -42,6 +42,6 @@ jobs:
           REPOSITORY: im-label-studio
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ../../Dockerfile
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -13,19 +13,21 @@ on:
         required: true
         default: "true"      
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   DeployLabelStudio:
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) || github.event_name == 'push'
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::626309225955:role/AssumeRoleLabelStudioRepo
+          role-session-name: DeployLabelStudio
           aws-region: us-east-1
       - name: Get Caller Identity
         run: aws sts get-caller-identity

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -1,6 +1,6 @@
 name: Deploy Label Studio
 
-# Continuous LDSDK jobs on all branches but feature branches. In feature branches, they will get triggered by pull request
+# Deploy Label Studio to ECR on push to main branch or manually via workflow_dispatch
 on:
   push:
     branches:
@@ -15,9 +15,8 @@ on:
 
 jobs:
   DeployLabelStudio:
-    runs-on: [self-hosted]
-    if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) ||
-         github.event_name == 'push'
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) || github.event_name == 'push'
     steps:
       - name: Configure AWS Credentials
         id: creds
@@ -27,5 +26,18 @@ jobs:
           role-to-assume: arn:aws:iam::626309225955:role/AssumeRoleLabelStudioRepo
           output-credentials: true
       - name: Get Caller Identity
+        run: aws sts get-caller-identity
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: im-label-studio
+          IMAGE_TAG: ${{ github.sha }}
         run: |
-          aws sts get-caller-identity
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -36,12 +36,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           mask-password: 'true'
+      - name: LS
+        run: ls -la
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: im-label-studio
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ../../Dockerfile
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG Dockerfile
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -23,6 +23,8 @@ jobs:
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.BuildPushImage == 'true')) || github.event_name == 'push'
     steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -36,16 +38,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           mask-password: 'true'
-      - name: LS
-        run: ls -la
-      - name: LS backwards
-        run: ls -la ../label-studio/
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: im-label-studio
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ${GITHUB_WORKSPACE}/Dockerfile
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,4 +1,4 @@
-python3.8 -m venv env
+python3 -m venv env
 source env/bin/activate
 python -m pip install label-studio
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,6 +1,4 @@
-python3 -m venv env
-source env/bin/activate
-python -m pip install label-studio
+python3 -m pip install label-studio
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if bash ${SCRIPT_DIR}/../deploy/prebuild.sh; then
   docker build -t heartexlabs/label-studio ${SCRIPT_DIR}/..

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,3 +1,4 @@
+pip install django label-studio
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if bash ${SCRIPT_DIR}/../deploy/prebuild.sh; then
   docker build -t heartexlabs/label-studio ${SCRIPT_DIR}/..

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,5 +1,7 @@
+python3 -m venv env
+source env/bin/activate
+python -m pip install label-studio
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 if bash ${SCRIPT_DIR}/../deploy/prebuild.sh; then
   docker build -t heartexlabs/label-studio ${SCRIPT_DIR}/..
 fi

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,4 +1,6 @@
-pip install django label-studio
+python3.8 -m venv env
+source env/bin/activate
+python -m pip install label-studio
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if bash ${SCRIPT_DIR}/../deploy/prebuild.sh; then
   docker build -t heartexlabs/label-studio ${SCRIPT_DIR}/..

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,4 +1,3 @@
-python3 -m pip install label-studio
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if bash ${SCRIPT_DIR}/../deploy/prebuild.sh; then
   docker build -t heartexlabs/label-studio ${SCRIPT_DIR}/..


### PR DESCRIPTION
## WHAT/WHY:

This PR introduces a deployment workflow to enable automatic deployment of Label Studio to an Amazon ECR in private repository. The workflow triggers on _main_ branch pushes or manual _workflow_dispatch_.

It auto-builds, tags, and pushes the app's Docker image to an ECR repository, facilitating smoother management and distribution.

## HOW:

- OIDC Setup: OIDC (OpenID Connect) is used for secure interactions with GitHub's OIDC Token endpoint.

- GitHub Token Permissions: Workflow uses the write ID token and read contents permissions.

- Deployment Steps: Upon trigger, the workflow:
- [ X ] Checks out code.
- [ X ] Configures AWS credentials, assuming role **AssumeRoleLabelStudioRepo**.
- [ X ] Logs in to Amazon ECR using `aws-actions/amazon-ecr-login@v1`
- [ X ] Builds, tags, and pushes Docker image to private ECR.